### PR TITLE
Add to_be_a_bag family

### DIFF
--- a/lib/Test/Kantan/Expect.pm
+++ b/lib/Test/Kantan/Expect.pm
@@ -105,21 +105,21 @@ sub to_be_a {
 
 sub to_be_an { goto \&to_be_a }
 
-sub to_equal_as_a_bag {
+sub to_equal_as_a_bag_of {
     my ($self, $expected) = @_;
 
     $self->to_equal(Test::Deep::bag(@{$expected}));
 }
 
-sub to_be_a_bag_of { goto \&to_equal_as_a_bag }
+sub to_be_a_bag_of { goto \&to_equal_as_a_bag_of }
 
-sub to_equal_as_a_set {
+sub to_equal_as_a_set_of {
     my ($self, $expected) = @_;
 
     $self->to_equal(Test::Deep::set(@{$expected}));
 }
 
-sub to_be_a_set_of { goto \&to_equal_as_a_set }
+sub to_be_a_set_of { goto \&to_equal_as_a_set_of }
 
 sub to_be_a_sub_bag_of {
     my ($self, $expected) = @_;
@@ -210,9 +210,9 @@ Pass if $x matches $re.
 
 Pass if C<< $x->$_isa($v) >> is true.
 
-=item C<< expect($x)->to_equal_as_a_set($v : ArrayRef) >>
+=item C<< expect($x)->to_equal_as_a_set_of($v : ArrayRef) >>
 
-=item C<< expect($x)->to_be_a_set($v : ArrayRef) >>
+=item C<< expect($x)->to_be_a_set_of($v : ArrayRef) >>
 
 =item C<< expect($x)->to_be_a_sub_set_of($v : ArrayRef) >>
 
@@ -220,9 +220,9 @@ Pass if C<< $x->$_isa($v) >> is true.
 
 Pass if $x to equal $v but ignores the order of the elements.
 
-=item C<< expect($x)->to_equal_as_a_bag($v : ArrayRef) >>
+=item C<< expect($x)->to_equal_as_a_bag_of($v : ArrayRef) >>
 
-=item C<< expect($x)->to_be_a_bag($v : ArrayRef) >>
+=item C<< expect($x)->to_be_a_bag_of($v : ArrayRef) >>
 
 =item C<< expect($x)->to_be_a_sub_bag_of($v : ArrayRef) >>
 

--- a/lib/Test/Kantan/Expect.pm
+++ b/lib/Test/Kantan/Expect.pm
@@ -119,7 +119,7 @@ sub to_equal_as_a_set {
     $self->to_equal(Test::Deep::set(@{$expected}));
 }
 
-sub to_be_a_set_of { goto \&to_equal_as_a_bag }
+sub to_be_a_set_of { goto \&to_equal_as_a_set }
 
 sub to_be_a_sub_bag_of {
     my ($self, $expected) = @_;

--- a/lib/Test/Kantan/Expect.pm
+++ b/lib/Test/Kantan/Expect.pm
@@ -105,6 +105,58 @@ sub to_be_a {
 
 sub to_be_an { goto \&to_be_a }
 
+sub to_equal_as_a_bag {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::bag(@{$expected}));
+}
+
+sub to_be_a_bag_of { goto \&to_equal_as_a_bag }
+
+sub to_equal_as_a_set {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::set(@{$expected}));
+}
+
+sub to_be_a_set_of { goto \&to_equal_as_a_bag }
+
+sub to_be_a_sub_bag_of {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::subbagof(@{$expected}));
+}
+
+sub to_be_a_sub_set_of {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::subsetof(@{$expected}));
+}
+
+sub to_be_a_super_bag_of {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::superbagof(@{$expected}));
+}
+
+sub to_be_a_super_set_of {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::supersetof(@{$expected}));
+}
+
+sub to_be_a_sub_hash_of {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::subhashof($expected));
+}
+
+sub to_be_a_super_hash_of {
+    my ($self, $expected) = @_;
+
+    $self->to_equal(Test::Deep::superhashof($expected));
+}
+
 1;
 __END__
 
@@ -157,5 +209,31 @@ Pass if $x matches $re.
 =item C<< expect($x)->to_be_an($v : Regexp) >>
 
 Pass if C<< $x->$_isa($v) >> is true.
+
+=item C<< expect($x)->to_equal_as_a_set($v : ArrayRef) >>
+
+=item C<< expect($x)->to_be_a_set($v : ArrayRef) >>
+
+=item C<< expect($x)->to_be_a_sub_set_of($v : ArrayRef) >>
+
+=item C<< expect($x)->to_be_a_super_set_of($v : ArrayRef) >>
+
+Pass if $x to equal $v but ignores the order of the elements.
+
+=item C<< expect($x)->to_equal_as_a_bag($v : ArrayRef) >>
+
+=item C<< expect($x)->to_be_a_bag($v : ArrayRef) >>
+
+=item C<< expect($x)->to_be_a_sub_bag_of($v : ArrayRef) >>
+
+=item C<< expect($x)->to_be_a_super_bag_of($v : ArrayRef) >>
+
+Pass if $x to equal $v but ignores the order of the elements and it ignores duplicate elements.
+
+=item C<< expect($x)->to_be_a_sub_hash_of($v : HashRef) >>
+
+=item C<< expect($x)->to_be_a_super_hash_of($v : HashRef) >>
+
+Pass if $x is a "super-hash" or "sub-hash" of $v.
 
 =back

--- a/t/02_expect.t
+++ b/t/02_expect.t
@@ -103,20 +103,20 @@ subtest 'to_be_a', sub {
     ok !expect(A->new)->to_be_a('C');
 };
 
-subtest 'to_equal_as_a_bag' => sub {
-    is( expect( [] )->to_equal_as_a_bag( [] ), 1 );
-    is( expect( [0, 1, 2] )->to_equal_as_a_bag( [0, 1, 2] ), 1 );
-    is( expect( [0, 1, 2] )->to_equal_as_a_bag( [2, 0, 1] ), 1 );
-    is( expect( [0, 1, 2, 2] )->to_equal_as_a_bag( [0, 1, 2] ), 0 );
-    is( expect( [0, 1, 2] )->to_equal_as_a_bag( [1, 2, 3] ), 0 );
+subtest 'to_equal_as_a_bag_of' => sub {
+    is( expect( [] )->to_equal_as_a_bag_of( [] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_bag_of( [0, 1, 2] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_bag_of( [2, 0, 1] ), 1 );
+    is( expect( [0, 1, 2, 2] )->to_equal_as_a_bag_of( [0, 1, 2] ), 0 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_bag_of( [1, 2, 3] ), 0 );
 };
 
-subtest 'to_equal_as_a_set' => sub {
-    is( expect( [] )->to_equal_as_a_set( [] ), 1 );
-    is( expect( [0, 1, 2] )->to_equal_as_a_set( [0, 1, 2] ), 1 );
-    is( expect( [0, 1, 2] )->to_equal_as_a_set( [2, 0, 1] ), 1 );
-    is( expect( [0, 1, 2, 2] )->to_equal_as_a_set( [0, 1, 2] ), 1 );
-    is( expect( [0, 1, 2] )->to_equal_as_a_set( [1, 2, 3] ), 0 );
+subtest 'to_equal_as_a_set_of' => sub {
+    is( expect( [] )->to_equal_as_a_set_of( [] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_set_of( [0, 1, 2] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_set_of( [2, 0, 1] ), 1 );
+    is( expect( [0, 1, 2, 2] )->to_equal_as_a_set_of( [0, 1, 2] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_set_of( [1, 2, 3] ), 0 );
 };
 
 subtest 'to_be_a_sub_bag_of' => sub {

--- a/t/02_expect.t
+++ b/t/02_expect.t
@@ -103,5 +103,62 @@ subtest 'to_be_a', sub {
     ok !expect(A->new)->to_be_a('C');
 };
 
+subtest 'to_equal_as_a_bag' => sub {
+    is( expect( [] )->to_equal_as_a_bag( [] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_bag( [0, 1, 2] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_bag( [2, 0, 1] ), 1 );
+    is( expect( [0, 1, 2, 2] )->to_equal_as_a_bag( [0, 1, 2] ), 0 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_bag( [1, 2, 3] ), 0 );
+};
+
+subtest 'to_equal_as_a_set' => sub {
+    is( expect( [] )->to_equal_as_a_set( [] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_set( [0, 1, 2] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_set( [2, 0, 1] ), 1 );
+    is( expect( [0, 1, 2, 2] )->to_equal_as_a_set( [0, 1, 2] ), 1 );
+    is( expect( [0, 1, 2] )->to_equal_as_a_set( [1, 2, 3] ), 0 );
+};
+
+subtest 'to_be_a_sub_bag_of' => sub {
+    is( expect( [] )->to_be_a_sub_bag_of( [] ), 1 );
+    is( expect( [1, 0] )->to_be_a_sub_bag_of( [0, 1] ), 1 );
+    is( expect( [1, 0] )->to_be_a_sub_bag_of( [0, 1, 2] ), 1 );
+    is( expect( [1, 0] )->to_be_a_sub_bag_of( [0, 2] ), 0 );
+    is( expect( [1, 0] )->to_be_a_sub_bag_of( [0] ), 0 );
+};
+
+subtest 'to_be_a_sub_set_of' => sub {
+    is( expect( [] )->to_be_a_sub_set_of( [] ), 1 );
+    is( expect( [1, 0] )->to_be_a_sub_set_of( [0, 1] ), 1 );
+    is( expect( [1, 0] )->to_be_a_sub_set_of( [0, 1, 2] ), 1 );
+    is( expect( [1, 0] )->to_be_a_sub_set_of( [0] ), 0 );
+};
+
+subtest 'to_be_a_super_bag_of' => sub {
+    is( expect( [] )->to_be_a_super_bag_of( [] ), 1 );
+    is( expect( [0, 1, 2] )->to_be_a_super_bag_of( [0, 1] ), 1 );
+    is( expect( [0, 1, 2] )->to_be_a_super_bag_of( [1, 0] ), 1 );
+    is( expect( [0, 1] )->to_be_a_super_bag_of( [2, 1, 0] ), 0 );
+};
+
+subtest 'to_be_a_super_set_of' => sub {
+    is( expect( [] )->to_be_a_super_set_of( [] ), 1 );
+    is( expect( [0, 1, 2] )->to_be_a_super_bag_of( [0, 1] ), 1 );
+    is( expect( [0, 1, 2] )->to_be_a_super_bag_of( [1, 0] ), 1 );
+    is( expect( [0, 1] )->to_be_a_super_bag_of( [2, 1, 0] ), 0 );
+};
+
+subtest 'to_be_a_sub_hash_of' => sub {
+    is( expect( {} )->to_be_a_sub_hash_of( {} ), 1 );
+    is( expect( {a => 0} )->to_be_a_sub_hash_of( {a => 0, b => 1} ), 1 );
+    is( expect( {a => 0, b => 1} )->to_be_a_sub_hash_of( {a => 0} ), 0 );
+};
+
+subtest 'to_be_a_super_hash_of' => sub {
+    is( expect( {} )->to_be_a_super_hash_of( {} ), 1 );
+    is( expect( {a => 0, b => 1} )->to_be_a_super_hash_of( {a => 0} ), 1 );
+    is( expect( {a => 0, b => 1} )->to_be_a_super_hash_of( {a => 0, c => 2} ), 0 );
+};
+
 done_testing;
 


### PR DESCRIPTION
I want to use some `Test::Deep` expectations such as `cmp_bag` on `Test::Kantan`.
In this pull request, I implemented `to_be_a_bag_of` that equals `cmp_bag`.

I considered 3 approaches to achieve the purpose;
- Add an expectation like `to_be_a_bag_of`
- Implement the Plugin mechanism, and add a Test::Deep plugin
- Add a "how-to-use with Test::Deep" to README

I choose the first approach, because this approach has 4 advantages over otherwise.
- Easier to be understood (User should not know what is `Test::Deep`)
- Users do not spend much cost if Test::Kantan take the Plugin mechanism
- Major test frameworks (rspec, chai, ...) intend to provide rich expectations
- Low-cost implementation
