### PR TITLE
use Win32::Console::ANSI on Windows to emulate ANSI sequences

### DIFF
--- a/lib/Test/Kantan/Reporter/Spec.pm
+++ b/lib/Test/Kantan/Reporter/Spec.pm
@@ -3,6 +3,9 @@ use strict;
 use warnings;
 use utf8;
 use 5.010_001;
+if ($^O eq 'MSWin32') {
+	eval "use Win32::Console::ANSI;"; # Only Windows 10 from 2020 supports ANSI sequences
+}
 use Term::ANSIColor ();
 use IO::Handle;
 


### PR DESCRIPTION
Simpler solution is to just disable color on Windows. Only recent versions of Windows 10 can activate ANSI via special console mode.